### PR TITLE
Non-interactive mode to output password to stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,15 @@
 Access your passwords saved in Google Chrome with CLI. Only expected to work on macOS.
 
 ```
-usage: pass [-h] [--profile PROFILE] [query]
+usage: pass [-h] [--profile PROFILE] [--out] [query]
 
 positional arguments:
   query
 
-optional arguments:
+options:
   -h, --help         show this help message and exit
   --profile PROFILE
+  --out              None-interactive; Output password to stdout
 ```
 
 See also [alfred-chrome-passwords](https://github.com/sadovnychyi/alfred-chrome-passwords).

--- a/pass
+++ b/pass
@@ -46,7 +46,7 @@ def decrypt(password):
   return ''.join([chr(i) for i in binary if i >= 32])
 
 
-def main(query, profile):
+def main(query, profile, out):
   passwords = []
   password2id = []
 
@@ -81,17 +81,32 @@ def main(query, profile):
   def copy(lines, _):
     pyperclip.copy(decrypt(password2id[int(lines[0].split()[-1])]))
 
-  with percol.Percol(actions=[copy], candidates=candidates(), query=query) as p:
-    percol.cli.load_rc(p)
-    p.view.PROMPT  = "<bold><yellow>Search</yellow></bold> %q" # type: ignore
-    p.view.CANDIDATES_LINE_SELECTED = ("underline", "on_blue", "black") # type: ignore
-    exit_code = p.loop()
-  exit(exit_code)
+  @percol.action.action()
+  def to_stdout(lines, _):
+    print(decrypt(password2id[int(lines[0].split()[-1])]), end='')
+
+  if out:
+    with percol.Percol(actions=[to_stdout], candidates=candidates(), query=query) as p:
+      percol.cli.load_rc(p)
+      p.model.do_search(p.model.query)
+      if len(p.model_candidate.get_selected_results_with_index()) == 1:
+        exit_code = p.finish_with_exit_code()
+      else:
+        exit_code = 1
+    exit(exit_code)
+  else:
+    with percol.Percol(actions=[copy], candidates=candidates(), query=query) as p:
+      percol.cli.load_rc(p)
+      p.view.PROMPT  = "<bold><yellow>Search</yellow></bold> %q" # type: ignore
+      p.view.CANDIDATES_LINE_SELECTED = ("underline", "on_blue", "black") # type: ignore
+      exit_code = p.loop()
+    exit(exit_code)
 
 
 if __name__ == '__main__':
   parser = argparse.ArgumentParser()
   parser.add_argument('query', default='', nargs='?')
   parser.add_argument('--profile', default=PROFILE)
+  parser.add_argument('--out', default=False, action='store_true', help='None-interactive; Output password to stdout')
   args = parser.parse_args()
-  main(args.query, args.profile)
+  main(args.query, args.profile, args.out)

--- a/pass
+++ b/pass
@@ -7,6 +7,7 @@ import os
 import sqlite3
 import tempfile
 from urllib.parse import urlparse
+import io
 import percol
 import percol.cli
 import percol.action
@@ -81,20 +82,20 @@ def main(query, profile, out):
   def copy(lines, _):
     pyperclip.copy(decrypt(password2id[int(lines[0].split()[-1])]))
 
-  @percol.action.action()
-  def to_stdout(lines, _):
-    print(decrypt(password2id[int(lines[0].split()[-1])]), end='')
-
   if out:
-    with percol.Percol(actions=[to_stdout], candidates=candidates(), query=query) as p:
-      percol.cli.load_rc(p)
-      p.model.do_search(p.model.query)
-      if len(p.model_candidate.get_selected_results_with_index()) == 1:
-        exit_code = p.finish_with_exit_code()
-      else:
-        exit_code = 1
+    # None-interactive, E.g. with --out
+    descriptors = {'stdin': io.StringIO(), 'stdout': io.StringIO(), 'stderr': io.StringIO()}
+    p = percol.Percol(actions=[], candidates=candidates(), query=query, descriptors=descriptors)
+    p.model.do_search(p.model.query)
+    results = p.model_candidate.get_selected_results_with_index()
+    if len(results) == 1:
+      print(decrypt(password2id[int(results[0][0].split()[-1])]), end='')
+      exit_code = 0
+    else:
+      exit_code = 1
     exit(exit_code)
   else:
+    # Interactive
     with percol.Percol(actions=[copy], candidates=candidates(), query=query) as p:
       percol.cli.load_rc(p)
       p.view.PROMPT  = "<bold><yellow>Search</yellow></bold> %q" # type: ignore


### PR DESCRIPTION
Add a non-interactive `--out` flag to output passwords to stdout instead of copying to clipboard.

Useful for handling passwords in config files, like .zshrc:

```
export MY_ENV_VAR=$(pass --out 'example.com.key.cli')
```